### PR TITLE
docs: add Venice OpenAI-compatible example

### DIFF
--- a/rig/rig-core/README.md
+++ b/rig/rig-core/README.md
@@ -91,6 +91,11 @@ The following providers are available as separate companion-crates:
 - Fastembed: [`rig-fastembed`](https://github.com/0xPlaygrounds/rig/tree/main/rig-fastembed)
 - Google Vertex: [`rig-vertexai`](https://github.com/0xPlaygrounds/rig/tree/main/rig-vertexai)
 
+OpenAI-compatible Chat Completions endpoints can also be used through
+`rig::providers::openai` by overriding the base URL and switching the model to
+`.completions_api()`. For a concrete example using Venice.ai, see
+[`rig-core/examples/agent_with_venice.rs`](./examples/agent_with_venice.rs).
+
 ## Who is using Rig?
 Below is a non-exhaustive list of companies and people who are using Rig:
 - [St Jude](https://www.stjude.org/) - Using Rig for a chatbot utility as part of [`proteinpaint`](https://github.com/stjude/proteinpaint), a genomics visualisation tool.

--- a/rig/rig-core/examples/agent_with_venice.rs
+++ b/rig/rig-core/examples/agent_with_venice.rs
@@ -1,0 +1,42 @@
+use rig::prelude::*;
+use rig::{completion::Prompt, providers::openai};
+use serde_json::json;
+
+const VENICE_API_BASE_URL: &str = "https://api.venice.ai/api/v1";
+const VENICE_UNCENSORED: &str = "venice-uncensored";
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let api_key = std::env::var("VENICE_API_KEY")
+        .or_else(|_| std::env::var("OPENAI_API_KEY"))
+        .expect("Set VENICE_API_KEY (or OPENAI_API_KEY) before running this example");
+
+    // Venice exposes an OpenAI-compatible Chat Completions API, so we point Rig's
+    // OpenAI client at Venice's base URL and switch the model to Completions mode.
+    let client = openai::Client::builder()
+        .api_key(&api_key)
+        .base_url(VENICE_API_BASE_URL)
+        .build()?;
+
+    let agent = client
+        .completion_model(VENICE_UNCENSORED)
+        .completions_api()
+        .into_agent_builder()
+        .preamble("You are a privacy-focused AI assistant.")
+        .temperature(0.7)
+        .additional_params(json!({
+            "venice_parameters": {
+                "enable_web_search": "auto",
+                "include_venice_system_prompt": true
+            }
+        }))
+        .build();
+
+    let response = agent
+        .prompt("Give me three concise ideas for a privacy-first AI product.")
+        .await?;
+
+    println!("{response}");
+
+    Ok(())
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a `rig-core` example showing how to use Venice.ai via Rig's OpenAI-compatible client
- document the OpenAI-compatible Chat Completions path in the `rig-core` README
- demonstrate how to pass Venice-specific request options through `additional_params`

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test

## Notes
- This change keeps Venice usage on Rig's existing OpenAI-compatible surface instead of introducing a new provider abstraction.
- I did not open a tracking issue; this is intended as a small documentation/example contribution.
- This PR was significantly generated by AI assistance.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a12461f6-e409-4bcb-b835-f60aacce6596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a12461f6-e409-4bcb-b835-f60aacce6596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

