### PR TITLE
feat: add Venice OpenAI-compatible example

### DIFF
--- a/rig/rig-core/examples/agent_with_venice.rs
+++ b/rig/rig-core/examples/agent_with_venice.rs
@@ -1,0 +1,39 @@
+use rig::completion::Prompt;
+use rig::prelude::*;
+use rig::providers::openai;
+use serde_json::json;
+use std::env;
+
+const VENICE_API_BASE_URL: &str = "https://api.venice.ai/api/v1";
+const VENICE_UNCENSORED: &str = "venice-uncensored";
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let api_key = env::var("VENICE_API_KEY").expect("VENICE_API_KEY not set");
+
+    // Venice exposes an OpenAI-compatible Chat Completions API, so Rig's OpenAI
+    // client can target it by overriding the base URL.
+    let agent = openai::Client::builder()
+        .api_key(api_key)
+        .base_url(VENICE_API_BASE_URL)
+        .build()?
+        .completions_api()
+        .agent(VENICE_UNCENSORED)
+        .preamble("You are a privacy-first research assistant.")
+        .temperature(0.7)
+        .additional_params(json!({
+            "venice_parameters": {
+                "enable_web_search": "auto",
+                "include_venice_system_prompt": true
+            }
+        }))
+        .build();
+
+    let response = agent
+        .prompt("Explain why teams might choose an OpenAI-compatible API in two sentences.")
+        .await?;
+
+    println!("{response}");
+
+    Ok(())
+}

--- a/rig/rig-core/src/providers/openai/client.rs
+++ b/rig/rig-core/src/providers/openai/client.rs
@@ -209,6 +209,7 @@ impl ProviderClient for Client {
     type Input = OpenAIApiKey;
 
     /// Create a new OpenAI Responses API client from the `OPENAI_API_KEY` environment variable.
+    /// If `OPENAI_BASE_URL` is set, requests are routed to that OpenAI-compatible base URL instead.
     /// Panics if the environment variable is not set.
     fn from_env() -> Self {
         let base_url: Option<String> = std::env::var("OPENAI_BASE_URL").ok();
@@ -232,6 +233,7 @@ impl ProviderClient for CompletionsClient {
     type Input = OpenAIApiKey;
 
     /// Create a new OpenAI Completions API client from the `OPENAI_API_KEY` environment variable.
+    /// If `OPENAI_BASE_URL` is set, requests are routed to that OpenAI-compatible base URL instead.
     /// Panics if the environment variable is not set.
     fn from_env() -> Self {
         let base_url: Option<String> = std::env::var("OPENAI_BASE_URL").ok();

--- a/rig/rig-core/src/providers/openai/mod.rs
+++ b/rig/rig-core/src/providers/openai/mod.rs
@@ -1,5 +1,7 @@
 //! OpenAI API client and Rig integration
 //!
+//! This client also works with OpenAI-compatible APIs by overriding the base URL.
+//!
 //! # Example
 //! ```
 //! use rig::providers::openai;
@@ -7,6 +9,18 @@
 //! let client = openai::Client::new("YOUR_API_KEY");
 //!
 //! let gpt4o = client.completion_model(openai::GPT_4O);
+//! ```
+//!
+//! ```no_run
+//! use rig::providers::openai;
+//!
+//! let client = openai::Client::builder()
+//!     .api_key("YOUR_VENICE_API_KEY")
+//!     .base_url("https://api.venice.ai/api/v1")
+//!     .build()?;
+//!
+//! let model = client.completions_api().completion_model("venice-uncensored");
+//! # Ok::<(), rig::client::ClientBuilderError>(())
 //! ```
 pub mod client;
 pub mod completion;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a small `rig-core` example showing how to use Venice via Rig's existing OpenAI-compatible client path
- document the OpenAI base URL override in the OpenAI provider module docs
- clarify in the OpenAI env-based constructors that `OPENAI_BASE_URL` can target another OpenAI-compatible endpoint

## Implementation notes
This keeps the change within Rig's current provider surface instead of introducing a Venice-specific provider. The example uses the OpenAI client builder with Venice's OpenAI-compatible base URL and routes Venice-only request fields through `additional_params`.

No linked issue was provided for this minor, scoped example/docs change.

## Verification
- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo check -p rig-core --example agent_with_venice`
- `cargo test --example agent_with_venice -p rig-core`

## Notes
- `cargo test` for the full workspace still fails in this environment due to unrelated Docker-dependent `rig-mongodb` integration tests (`/var/run/docker.sock` unavailable).
- `cargo test -p rig-core --all-features` still fails on a pre-existing unrelated test: `vector_store::in_memory_store::tests::test_multiple_embeddings`.
- This PR was generated with significant AI assistance.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d36d72e-7789-4997-a20f-e0c31dd70c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d36d72e-7789-4997-a20f-e0c31dd70c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

